### PR TITLE
Bump vale to 2.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@ocular-d/vale-bin",
-	"version": "1.0.4",
-	"valeVersion": "2.10.1",
+	"version": "1.0.5",
+	"valeVersion": "2.10.2",
 	"description": "Vale wrapper",
 	"main": "index.js",
 	"bin": {


### PR DESCRIPTION
Vale 2.10.2 fixes ls-config and the vscode extension from [discussions here](https://github.com/errata-ai/vale-vscode/issues/49)

Looks like the wrapper just needs the `package.json` bump so I've added that in. Let me know if anything else is required!