### PR TITLE
Support macOS with arm64 architecture

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const url = `https://github.com/errata-ai/vale/releases/download/v${pkgjson.vale
 
 module.exports = new BinWrapper()
 	.src(`${url}_macOS_64-bit.tar.gz`, 'darwin', 'x64')
+	.src(`${url}_macOS_64-bit.tar.gz`, 'darwin', 'arm64')
 	.src(`${url}_Linux_64-bit.tar.gz`, 'linux', 'x64')
 	.src(`${url}_Windows_64bit.zip`, 'win32', 'x64')
 	.dest(path.resolve(__dirname, '../vendor'))


### PR DESCRIPTION
In an arm64 macOS environment (M1 MacBook for example), this package fails to install:
```sh
@ocular-d/vale-bin <err> Error: Failed to find source that matches darwin arm64
@ocular-d/vale-bin <err> vale failed to download
```

I've tested this change locally and can confirm it works as expected on my M1 MacBook Pro.