### PR TITLE
Fix macOS arm64 loading

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const url = `https://github.com/errata-ai/vale/releases/download/v${pkgjson.vale
 
 module.exports = new BinWrapper()
 	.src(`${url}_macOS_64-bit.tar.gz`, 'darwin', 'x64')
-	.src(`${url}_macOS_64-bit.tar.gz`, 'darwin', 'arm64')
+	.src(`${url}_macOS_arm64.tar.gz`, 'darwin', 'arm64')
 	.src(`${url}_Linux_64-bit.tar.gz`, 'linux', 'x64')
 	.src(`${url}_Windows_64-bit.zip`, 'win32', 'x64')
 	.dest(path.resolve(__dirname, '../vendor'))


### PR DESCRIPTION
At some point it looks like vale started publishing a separate binary for arm64, see: https://github.com/errata-ai/vale/releases/tag/v2.26.0

Anyway, this change fixes #9 for me